### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ But open an issue to talk about the API first, OK?
 
 ## Contributing
 
-This probject uses [Nix](https://nixos.org/download.html) to manage versions (but just need a `nix` installation, not NixOS, so this will work on macOS.)
+This project uses [Nix](https://nixos.org/download.html) to manage versions (but just need a `nix` installation, not NixOS, so this will work on macOS.)
 Install that, then run `nix-shell` to get into a development environment.
 
 Things I'd appreciate help with:
@@ -109,7 +109,7 @@ Things I'd appreciate help with:
 
 - Feedback on speed.
   For the data sizes I'm working with in my use of this library, speed is unlikely to be an issue.
-  If you're parsing a *lot* of data, thought, it may be for you.
+  If you're parsing a *lot* of data, though, it may be for you.
   If you find that this library has become a bottleneck in your application, please open an issue.
 
 - Feedback on decoders for things you find necessary (but please open an issue and talk through it instead of jumping straight to a PR!)

--- a/src/Csv/Decode.elm
+++ b/src/Csv/Decode.elm
@@ -355,7 +355,7 @@ applyDecoder fieldNames (Decoder decode) allRows =
 
 
 {-| Sometimes things go wrong. This is how we tell you what happened. If you
-need to present this to somone, you can get a human-readable version with
+need to present this to someone, you can get a human-readable version with
 [`errorToString`](#errorToString)
 
 Some more detail:


### PR DESCRIPTION
I just went through the documentation, and saw a few typos. By habit, I make PRs to fix the ones I see :)

One thing that looked pretty off but that I decided not to fix was in the README

> I don't want to add the new dependencies on `elm/json`

Did you mean `BrianHicks/elm-csv` instead of `elm/json`?

Thanks for the library, it looks boringly good :grin: 

(also, I saw the `elm-review` commit, feel free to get in touch if you think I can help, I know nothing about Nix)