### PR TITLE
Fix typo in doc example

### DIFF
--- a/src/Csv/Decode.elm
+++ b/src/Csv/Decode.elm
@@ -694,7 +694,7 @@ do something like this:
 
 You could then use it like this:
 
-    decodeCsv NoFieldNames positiveint "1" -- Ok [ 1 ]
+    decodeCsv NoFieldNames positiveInt "1" -- Ok [ 1 ]
 
     decodeCsv NoFieldNames positiveInt "-1"
     -- Err { row = 0, problem = Failure "Only positive numbers allowed!" }


### PR DESCRIPTION
Hello, thank you for this nice package. I've found a small typo in the docs.