### PR TITLE
Fix trailing newlines

### DIFF
--- a/src/Csv/Parser.elm
+++ b/src/Csv/Parser.elm
@@ -182,162 +182,170 @@ parse config source =
 
         parseComma : List String -> List (List String) -> Int -> Int -> Result Problem (List (List String))
         parseComma row rows startOffset endOffset =
-            if endOffset - finalLength >= 0 then
+            let
+                first : String
+                first =
+                    String.slice endOffset (endOffset + 1) source
+            in
+            if first == "" then
                 let
-                    finalRow : List String
-                    finalRow =
-                        List.reverse (String.slice startOffset endOffset source :: row)
+                    finalField : String
+                    finalField =
+                        String.slice startOffset endOffset source
                 in
-                Ok (List.reverse (finalRow :: rows))
-
-            else
-                let
-                    first : String
-                    first =
-                        String.slice endOffset (endOffset + 1) source
-                in
-                if first == "," then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    parseComma
-                        (String.slice startOffset endOffset source :: row)
-                        rows
-                        newPos
-                        newPos
-
-                else if first == "\n" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    parseComma
-                        []
-                        (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
-                        newPos
-                        newPos
-
-                else if first == "\u{000D}" && String.slice (endOffset + 1) (endOffset + 2) source == "\n" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 2
-                    in
-                    parseComma
-                        []
-                        (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
-                        newPos
-                        newPos
-
-                else if first == "\"" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    case parseQuotedField (\s -> s == ",") [] newPos newPos of
-                        Ok ( value, afterQuotedField ) ->
-                            if afterQuotedField >= finalLength then
-                                Ok (List.reverse (List.reverse (value :: row) :: rows))
-
-                            else
-                                parseComma (value :: row) rows afterQuotedField afterQuotedField
-
-                        Err problem ->
-                            Err (problem (List.length rows + 1))
+                if finalField == "" && row == [] then
+                    Ok (List.reverse rows)
 
                 else
-                    parseComma
-                        row
-                        rows
-                        startOffset
-                        (endOffset + 1)
+                    Ok (List.reverse (List.reverse (finalField :: row) :: rows))
+
+            else if first == "," then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                parseComma
+                    (String.slice startOffset endOffset source :: row)
+                    rows
+                    newPos
+                    newPos
+
+            else if first == "\n" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                parseComma
+                    []
+                    (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
+                    newPos
+                    newPos
+
+            else if first == "\u{000D}" && String.slice (endOffset + 1) (endOffset + 2) source == "\n" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 2
+                in
+                parseComma
+                    []
+                    (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
+                    newPos
+                    newPos
+
+            else if first == "\"" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                case parseQuotedField (\c -> c == ",") [] newPos newPos of
+                    Ok ( value, afterQuotedField ) ->
+                        if afterQuotedField >= finalLength then
+                            Ok (List.reverse (List.reverse (value :: row) :: rows))
+
+                        else
+                            parseComma (value :: row) rows afterQuotedField afterQuotedField
+
+                    Err problem ->
+                        Err (problem (List.length rows + 1))
+
+            else
+                parseComma
+                    row
+                    rows
+                    startOffset
+                    (endOffset + 1)
 
         parseSemicolon : List String -> List (List String) -> Int -> Int -> Result Problem (List (List String))
         parseSemicolon row rows startOffset endOffset =
-            if endOffset - finalLength >= 0 then
+            let
+                first : String
+                first =
+                    String.slice endOffset (endOffset + 1) source
+            in
+            if first == "" then
                 let
-                    finalRow : List String
-                    finalRow =
-                        List.reverse (String.slice startOffset endOffset source :: row)
+                    finalField : String
+                    finalField =
+                        String.slice startOffset endOffset source
                 in
-                Ok (List.reverse (finalRow :: rows))
-
-            else
-                let
-                    first : String
-                    first =
-                        String.slice endOffset (endOffset + 1) source
-                in
-                if first == ";" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    parseSemicolon
-                        (String.slice startOffset endOffset source :: row)
-                        rows
-                        newPos
-                        newPos
-
-                else if first == "\n" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    parseSemicolon
-                        []
-                        (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
-                        newPos
-                        newPos
-
-                else if first == "\u{000D}" && String.slice (endOffset + 1) (endOffset + 2) source == "\n" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 2
-                    in
-                    parseSemicolon
-                        []
-                        (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
-                        newPos
-                        newPos
-
-                else if first == "\"" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    case parseQuotedField (\s -> s == ";") [] newPos newPos of
-                        Ok ( value, afterQuotedField ) ->
-                            if afterQuotedField >= finalLength then
-                                Ok (List.reverse (List.reverse (value :: row) :: rows))
-
-                            else
-                                parseSemicolon (value :: row) rows afterQuotedField afterQuotedField
-
-                        Err problem ->
-                            Err (problem (List.length rows + 1))
+                if finalField == "" && row == [] then
+                    Ok (List.reverse rows)
 
                 else
-                    parseSemicolon
-                        row
-                        rows
-                        startOffset
-                        (endOffset + 1)
+                    Ok (List.reverse (List.reverse (finalField :: row) :: rows))
+
+            else if first == ";" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                parseSemicolon
+                    (String.slice startOffset endOffset source :: row)
+                    rows
+                    newPos
+                    newPos
+
+            else if first == "\n" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                parseSemicolon
+                    []
+                    (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
+                    newPos
+                    newPos
+
+            else if first == "\u{000D}" && String.slice (endOffset + 1) (endOffset + 2) source == "\n" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 2
+                in
+                parseSemicolon
+                    []
+                    (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
+                    newPos
+                    newPos
+
+            else if first == "\"" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                case parseQuotedField (\c -> c == ";") [] newPos newPos of
+                    Ok ( value, afterQuotedField ) ->
+                        if afterQuotedField >= finalLength then
+                            Ok (List.reverse (List.reverse (value :: row) :: rows))
+
+                        else
+                            parseSemicolon (value :: row) rows afterQuotedField afterQuotedField
+
+                    Err problem ->
+                        Err (problem (List.length rows + 1))
+
+            else
+                parseSemicolon
+                    row
+                    rows
+                    startOffset
+                    (endOffset + 1)
     in
     if String.isEmpty source then
         Ok []
-        -- else if config.fieldSeparator == ',' then
-        --     parseComma [] [] 0 0
-        -- else if config.fieldSeparator == ';' then
-        --     parseSemicolon [] [] 0 0
+
+    else if config.fieldSeparator == ',' then
+        parseComma [] [] 0 0
+
+    else if config.fieldSeparator == ';' then
+        parseSemicolon [] [] 0 0
 
     else
         parseHelp (\s -> s == fieldSeparator) [] [] 0 0

--- a/src/Csv/Parser.elm
+++ b/src/Csv/Parser.elm
@@ -99,83 +99,86 @@ parse config source =
 
         parseHelp : (String -> Bool) -> List String -> List (List String) -> Int -> Int -> Result Problem (List (List String))
         parseHelp isFieldSeparator row rows startOffset endOffset =
-            if endOffset - finalLength >= 0 then
+            let
+                first : String
+                first =
+                    String.slice endOffset (endOffset + 1) source
+            in
+            if first == "" then
                 let
-                    finalRow : List String
-                    finalRow =
-                        List.reverse (String.slice startOffset endOffset source :: row)
+                    finalField : String
+                    finalField =
+                        String.slice startOffset endOffset source
                 in
-                Ok (List.reverse (finalRow :: rows))
-
-            else
-                let
-                    first : String
-                    first =
-                        String.slice endOffset (endOffset + 1) source
-                in
-                if isFieldSeparator first then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    parseHelp
-                        isFieldSeparator
-                        (String.slice startOffset endOffset source :: row)
-                        rows
-                        newPos
-                        newPos
-
-                else if first == "\n" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    parseHelp
-                        isFieldSeparator
-                        []
-                        (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
-                        newPos
-                        newPos
-
-                else if first == "\u{000D}" && String.slice (endOffset + 1) (endOffset + 2) source == "\n" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 2
-                    in
-                    parseHelp
-                        isFieldSeparator
-                        []
-                        (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
-                        newPos
-                        newPos
-
-                else if first == "\"" then
-                    let
-                        newPos : Int
-                        newPos =
-                            endOffset + 1
-                    in
-                    case parseQuotedField isFieldSeparator [] newPos newPos of
-                        Ok ( value, afterQuotedField ) ->
-                            if afterQuotedField >= finalLength then
-                                Ok (List.reverse (List.reverse (value :: row) :: rows))
-
-                            else
-                                parseHelp isFieldSeparator (value :: row) rows afterQuotedField afterQuotedField
-
-                        Err problem ->
-                            Err (problem (List.length rows + 1))
+                if finalField == "" && row == [] then
+                    Ok (List.reverse rows)
 
                 else
-                    parseHelp
-                        isFieldSeparator
-                        row
-                        rows
-                        startOffset
-                        (endOffset + 1)
+                    Ok (List.reverse (List.reverse (finalField :: row) :: rows))
+
+            else if isFieldSeparator first then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                parseHelp
+                    isFieldSeparator
+                    (String.slice startOffset endOffset source :: row)
+                    rows
+                    newPos
+                    newPos
+
+            else if first == "\n" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                parseHelp
+                    isFieldSeparator
+                    []
+                    (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
+                    newPos
+                    newPos
+
+            else if first == "\u{000D}" && String.slice (endOffset + 1) (endOffset + 2) source == "\n" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 2
+                in
+                parseHelp
+                    isFieldSeparator
+                    []
+                    (List.reverse (String.slice startOffset endOffset source :: row) :: rows)
+                    newPos
+                    newPos
+
+            else if first == "\"" then
+                let
+                    newPos : Int
+                    newPos =
+                        endOffset + 1
+                in
+                case parseQuotedField isFieldSeparator [] newPos newPos of
+                    Ok ( value, afterQuotedField ) ->
+                        if afterQuotedField >= finalLength then
+                            Ok (List.reverse (List.reverse (value :: row) :: rows))
+
+                        else
+                            parseHelp isFieldSeparator (value :: row) rows afterQuotedField afterQuotedField
+
+                    Err problem ->
+                        Err (problem (List.length rows + 1))
+
+            else
+                parseHelp
+                    isFieldSeparator
+                    row
+                    rows
+                    startOffset
+                    (endOffset + 1)
 
         parseComma : List String -> List (List String) -> Int -> Int -> Result Problem (List (List String))
         parseComma row rows startOffset endOffset =
@@ -331,12 +334,10 @@ parse config source =
     in
     if String.isEmpty source then
         Ok []
-
-    else if config.fieldSeparator == ',' then
-        parseComma [] [] 0 0
-
-    else if config.fieldSeparator == ';' then
-        parseSemicolon [] [] 0 0
+        -- else if config.fieldSeparator == ',' then
+        --     parseComma [] [] 0 0
+        -- else if config.fieldSeparator == ';' then
+        --     parseSemicolon [] [] 0 0
 
     else
         parseHelp (\s -> s == fieldSeparator) [] [] 0 0

--- a/src/Csv/Parser.elm
+++ b/src/Csv/Parser.elm
@@ -180,6 +180,23 @@ parse config source =
                     startOffset
                     (endOffset + 1)
 
+        {- This and `parseSemicolon` below are just specialized versions of
+           `parseHelp` that produce more efficient generated code. The whole
+           trick here is to compare to literals instead of variables, which
+           makes the Elm compiler produce code that compares with `===`
+           instead of a helper function that implements value-level comparison.
+
+           To update these functions, just copy the body of `parseHelp`, then:
+
+            1. replace the calls to `isFieldSeparator` with literal equality
+               checks (e.g. `first == ","` in `parseComma`.)
+            2. create a new `isFieldSeparator` to pass to `parseQuotedField`
+               that does the same.
+
+           Benchmark numbers without these functions ported will appear to
+           be much slower, but it's fine to temporarily disable them in the
+           bottom `if` of this function to fix bugs and stuff.
+        -}
         parseComma : List String -> List (List String) -> Int -> Int -> Result Problem (List (List String))
         parseComma row rows startOffset endOffset =
             let


### PR DESCRIPTION
Decoding this:

`a,b,c\nd,e,f\n`

Now produces this:

```elm
[ [ "a", "b", "c" ]
, [ "d", "e", "f" ]
]
```

Instead of this:

```elm
[ [ "a", "b", "c" ]
, [ "d", "e", "f" ]
, [ "" ]
]
```

There don't seem to be any other regressions, I was just missing this test case.

Fixes #8 