### PR TITLE
Check for blank fields as any number of whitespace characters

### DIFF
--- a/src/Csv/Decode.elm
+++ b/src/Csv/Decode.elm
@@ -314,7 +314,7 @@ blank : Decoder a -> Decoder (Maybe a)
 blank decoder =
     andThen
         (\maybeBlank ->
-            if String.isEmpty maybeBlank then
+            if String.isEmpty (String.trim maybeBlank) then
                 succeed Nothing
 
             else

--- a/tests/Csv/DecodeTest.elm
+++ b/tests/Csv/DecodeTest.elm
@@ -142,6 +142,16 @@ blankTest =
                 ""
                     |> Decode.decodeCsv NoFieldNames (Decode.blank Decode.int)
                     |> Expect.equal (Ok [])
+        , test "when the field contains spaces" <|
+            \_ ->
+                "  "
+                    |> Decode.decodeCsv NoFieldNames (Decode.blank Decode.int)
+                    |> Expect.equal (Ok [ Nothing ])
+        , test "when the field contains whitespace characters" <|
+            \_ ->
+                "\"\u{00A0}\t\n\""
+                    |> Decode.decodeCsv NoFieldNames (Decode.blank Decode.int)
+                    |> Expect.equal (Ok [ Nothing ])
         , test "when the field is non-blank but not valid for the decoder" <|
             \_ ->
                 "banana"


### PR DESCRIPTION
Blank fields are now considered as any number of whitespace characters (space, tab, newline, non-breakable space, …).

I separated the test for spaces and the test for others characters. This allows also to test inside quotes (needed by the newline). Feel free to merge the tests if you prefer.

Fixes #16 