### PR TITLE
ignore trailing newlines after quoted fields

### DIFF
--- a/src/Csv/Parser.elm
+++ b/src/Csv/Parser.elm
@@ -51,7 +51,7 @@ parse config source =
                     segment =
                         String.slice startOffset endOffset source
                 in
-                if (endOffset + 2) - finalLength >= 0 then
+                if (endOffset + 1) - finalLength >= 0 then
                     Ok
                         ( soFar ++ segment
                         , endOffset + 1

--- a/tests/Csv/ParserTest.elm
+++ b/tests/Csv/ParserTest.elm
@@ -131,6 +131,12 @@ parseTest =
                                             , [ "Brazil", "212652000" ]
                                             ]
                                         )
+                        , test "a trailing newline after a quoted field should be ignored" <|
+                            -- https://github.com/BrianHicks/elm-csv/issues/24
+                            \_ ->
+                                ("\"val\"" ++ config.rowSeparator)
+                                    |> parse { fieldSeparator = config.fieldSeparator }
+                                    |> Expect.equal (Ok [ [ "val" ] ])
                         , describe "errors"
                             [ test "not ending a quoted value is an error" <|
                                 \_ ->


### PR DESCRIPTION
This should fix https://github.com/BrianHicks/elm-csv/issues/24

Simple fix, actually: we were adding enough offset to check for a `\r\n` but not just an `\n`, which meant we bailed out of parsing a quoted field without giving the information that we had completed the row.