### PR TITLE
Fixes map2 and map3 while improving error messages

### DIFF
--- a/src/Csv/Decode.elm
+++ b/src/Csv/Decode.elm
@@ -1,7 +1,7 @@
 module Csv.Decode exposing
     ( Decoder, string, int, float, blank
     , column, field
-    , FieldNames(..), decodeCsv, decodeCustom, Error(..), errorToString, Column(..), Problem(..)
+    , FieldNames(..), decodeCsv, decodeCustom, Error(..), DecodingError(..), errorToString, Column(..), Problem(..)
     , map, map2, map3, into, pipeline
     , oneOf, andThen, succeed, fail, fromResult, fromMaybe
     )
@@ -75,7 +75,7 @@ that takes more arguments.
 
 ## Running Decoders
 
-@docs FieldNames, decodeCsv, decodeCustom, Error, errorToString, Column, Problem
+@docs FieldNames, decodeCsv, decodeCustom, Error, DecodingError, errorToString, Column, Problem
 
 
 ## Transforming Values
@@ -91,6 +91,7 @@ that takes more arguments.
 
 import Csv.Parser as Parser
 import Dict exposing (Dict)
+import Set
 
 
 
@@ -106,13 +107,7 @@ type Decoder a
          -> Dict String Int
          -> Int
          -> List String
-         ->
-            Result
-                { row : Int
-                , column : Column
-                , problems : List Problem
-                }
-                a
+         -> Result (List DecodingError) a
         )
 
 
@@ -120,6 +115,16 @@ fromString : (String -> Result Problem a) -> Decoder a
 fromString convert =
     Decoder <|
         \location fieldNames rowNum row ->
+            let
+                error problem =
+                    Err
+                        [ FieldDecodingError
+                            { row = rowNum
+                            , column = locationToColumn fieldNames location
+                            , problem = problem
+                            }
+                        ]
+            in
             case location of
                 Column_ colNum ->
                     case row |> List.drop colNum |> List.head of
@@ -129,18 +134,10 @@ fromString convert =
                                     Ok converted
 
                                 Err problem ->
-                                    Err
-                                        { row = rowNum
-                                        , column = locationToColumn fieldNames location
-                                        , problems = [ problem ]
-                                        }
+                                    error problem
 
                         Nothing ->
-                            Err
-                                { row = rowNum
-                                , column = locationToColumn fieldNames location
-                                , problems = [ ColumnNotFound colNum ]
-                                }
+                            error (ColumnNotFound colNum)
 
                 Field_ name ->
                     case Dict.get name fieldNames of
@@ -152,34 +149,18 @@ fromString convert =
                                             Ok converted
 
                                         Err problem ->
-                                            Err
-                                                { row = rowNum
-                                                , column = locationToColumn fieldNames location
-                                                , problems = [ problem ]
-                                                }
+                                            error problem
 
                                 Nothing ->
-                                    Err
-                                        { row = rowNum
-                                        , column = locationToColumn fieldNames location
-                                        , problems = [ FieldNotFound name ]
-                                        }
+                                    error (FieldNotFound name)
 
                         Nothing ->
-                            Err
-                                { row = rowNum
-                                , column = locationToColumn fieldNames location
-                                , problems = [ FieldNotProvided name ]
-                                }
+                            Err [ FieldNotProvided name ]
 
                 OnlyColumn_ ->
                     case row of
                         [] ->
-                            Err
-                                { row = rowNum
-                                , column = locationToColumn fieldNames location
-                                , problems = [ ColumnNotFound 0 ]
-                                }
+                            error (ColumnNotFound 0)
 
                         [ only ] ->
                             case convert only of
@@ -187,18 +168,10 @@ fromString convert =
                                     Ok converted
 
                                 Err problem ->
-                                    Err
-                                        { row = rowNum
-                                        , column = locationToColumn fieldNames location
-                                        , problems = [ problem ]
-                                        }
+                                    error problem
 
                         _ ->
-                            Err
-                                { row = rowNum
-                                , column = locationToColumn fieldNames location
-                                , problems = [ ExpectedOneColumn (List.length row) ]
-                                }
+                            error (ExpectedOneColumn (List.length row))
 
 
 {-| Decode a string.
@@ -482,7 +455,7 @@ applyDecoder fieldNames (Decoder decode) allRows =
                     ( Ok [], firstRowNumber )
                 |> Tuple.first
                 |> Result.map List.reverse
-                |> Result.mapError (DecodingErrors << List.reverse)
+                |> Result.mapError (DecodingErrors << List.concat << List.reverse)
         )
         (getFieldNames fieldNames allRows)
 
@@ -500,19 +473,28 @@ Some more detail:
     row (using [`FieldNames`](#FieldNames)) but couldn't find any, probably
     because the input was blank.
   - `DecodingErrors`: we couldn't decode a value using the specified
-    decoder. See [`Problem`](#Problem) for more details.
+    decoder. See [`DecodingError`](#DecodingError) for more details.
 
 -}
 type Error
     = ParsingError Parser.Problem
     | NoFieldNamesOnFirstRow
-    | DecodingErrors
-        (List
-            { row : Int
-            , column : Column
-            , problems : List Problem
-            }
-        )
+    | DecodingErrors (List DecodingError)
+
+
+{-| Errors when decoding can either be:
+
+  - Focused on decoding a single field (`FieldDecodingError`), in which case there
+    is a specific [`Problem`](#Problem) in a specific location.
+  - A result of a [`oneOf`](#oneOf) where all branches failed (`OneOfDecodingError`).
+  - A problem with the header row or configuration where a column is simply
+    missing (`FieldNotProvided`).
+
+-}
+type DecodingError
+    = FieldDecodingError { row : Int, column : Column, problem : Problem }
+    | OneOfDecodingError Int (List DecodingError)
+    | FieldNotProvided String
 
 
 {-| Where did the problem happen?
@@ -547,9 +529,6 @@ locationToColumn fieldNames location =
   - `ColumnNotFound Int` and `FieldNotFound String`: we looked for the
     specified column, but couldn't find it. The argument specifies where we
     tried to look.
-  - `FieldNotProvided String`: we looked for a specific field, but it wasn't
-    present in the first row or the provided field names (depending on your
-    configuration.)
   - `ExpectedOneColumn Int`: basic decoders like [`string`](#string) and
     [`int`](#int) expect to find a single column per row. If there are multiple
     columns, and you don't specify which to use with [`column`](#column)
@@ -563,7 +542,6 @@ locationToColumn fieldNames location =
 type Problem
     = ColumnNotFound Int
     | FieldNotFound String
-    | FieldNotProvided String
     | ExpectedOneColumn Int
     | ExpectedInt String
     | ExpectedFloat String
@@ -595,9 +573,6 @@ errorToString error =
                         FieldNotFound name ->
                             "I couldn't find the `" ++ name ++ "` column."
 
-                        FieldNotProvided name ->
-                            "The `" ++ name ++ "` field wasn't provided in the field names."
-
                         ExpectedOneColumn howMany ->
                             "I expected exactly one column, but there were " ++ String.fromInt howMany ++ "."
 
@@ -610,57 +585,168 @@ errorToString error =
                         Failure custom ->
                             custom
 
-                rowAndColumnString : { a | row : Int, column : Column } -> String
-                rowAndColumnString err =
-                    "row "
-                        ++ String.fromInt err.row
-                        ++ ", "
-                        ++ (case err.column of
-                                Column col ->
-                                    "column " ++ String.fromInt col
+                columnString : { b | column : Column } -> String
+                columnString err =
+                    case err.column of
+                        Column col ->
+                            "column " ++ String.fromInt col
 
-                                Field name Nothing ->
-                                    "in the `" ++ name ++ "` field"
+                        Field name Nothing ->
+                            "in the `" ++ name ++ "` field"
 
-                                Field name (Just col) ->
-                                    "in the `" ++ name ++ "` field (column " ++ String.fromInt col ++ ")"
+                        Field name (Just col) ->
+                            "in the `" ++ name ++ "` field (column " ++ String.fromInt col ++ ")"
 
-                                OnlyColumn ->
-                                    "column 0 (the only column present)"
-                           )
+                        OnlyColumn ->
+                            "column 0 (the only column present)"
 
-                errString : { row : Int, column : Column, problems : List Problem } -> String
+                rowString : { a | startRow : Int, endRow : Int } -> String
+                rowString loc =
+                    case loc.endRow - loc.startRow of
+                        0 ->
+                            "row " ++ String.fromInt loc.startRow
+
+                        1 ->
+                            "rows " ++ String.fromInt loc.startRow ++ " and " ++ String.fromInt loc.endRow
+
+                        _ ->
+                            "rows " ++ String.fromInt loc.startRow ++ "–" ++ String.fromInt loc.endRow
+
+                errString : DecodingError -> String
                 errString err =
-                    case List.map problemString err.problems of
-                        [] ->
-                            "There was an internal error while generating an error on "
-                                ++ rowAndColumnString err
-                                ++ " and I don't have any info about what went wrong. Please open an issue!"
-
-                        [ only ] ->
-                            "There was a problem on "
-                                ++ rowAndColumnString err
+                    case err of
+                        FieldDecodingError fde ->
+                            columnString fde
                                 ++ ": "
-                                ++ only
+                                ++ problemString fde.problem
 
-                        many ->
-                            "There were some problems on "
-                                ++ rowAndColumnString err
-                                ++ ":\n\n"
-                                ++ String.join "\n" (List.map (\problem -> " - " ++ problem) many)
+                        OneOfDecodingError _ oodes ->
+                            "all of the following decoders failed, but at least one must succeed:\n"
+                                ++ String.join "\n"
+                                    (List.indexedMap
+                                        (\i e ->
+                                            "  (" ++ String.fromInt (i + 1) ++ ") " ++ errString e
+                                        )
+                                        oodes
+                                    )
+
+                        FieldNotProvided name ->
+                            "field " ++ name ++ "was not provided"
+
+                topLevelErrString : { startRow : Int, endRow : Int, error : DecodingError } -> String
+                topLevelErrString err =
+                    (case err.error of
+                        FieldDecodingError _ ->
+                            "There was a problem on " ++ rowString err ++ ", "
+
+                        OneOfDecodingError _ _ ->
+                            "There was a problem on " ++ rowString err ++ " - "
+
+                        FieldNotProvided _ ->
+                            "There was a problem in the header: "
+                    )
+                        ++ errString err.error
+
+                isContiguous : DecodingError -> DecodingError -> Bool
+                isContiguous errA errB =
+                    case ( errA, errB ) of
+                        ( FieldDecodingError a, FieldDecodingError b ) ->
+                            a.problem == b.problem && a.row + 1 == b.row && a.column == b.column
+
+                        ( OneOfDecodingError aRow aList, OneOfDecodingError bRow bList ) ->
+                            aRow + 1 == bRow && List.length aList == List.length bList && List.all identity (List.map2 isContiguous aList bList)
+
+                        _ ->
+                            errA == errB
+
+                getRow : DecodingError -> Int
+                getRow decErr =
+                    case decErr of
+                        FieldDecodingError e ->
+                            e.row
+
+                        OneOfDecodingError row _ ->
+                            row
+
+                        FieldNotProvided _ ->
+                            0
+
+                dedupeHelp :
+                    List { startRow : Int, endRow : Int, error : DecodingError }
+                    -> List DecodingError
+                    -> List DecodingError
+                    -> List { startRow : Int, endRow : Int, error : DecodingError }
+                dedupeHelp soFar prevGroup errors =
+                    case errors of
+                        [] ->
+                            case prevGroup of
+                                [] ->
+                                    List.reverse soFar
+
+                                head :: tail ->
+                                    List.reverse ({ startRow = List.reverse tail |> List.head |> Maybe.withDefault head |> getRow, endRow = getRow head, error = head } :: soFar)
+
+                        err :: rest ->
+                            case prevGroup of
+                                [] ->
+                                    dedupeHelp soFar (err :: prevGroup) rest
+
+                                head :: tail ->
+                                    if isContiguous head err then
+                                        dedupeHelp soFar (err :: prevGroup) rest
+
+                                    else
+                                        dedupeHelp ({ startRow = List.reverse tail |> List.head |> Maybe.withDefault head |> getRow, endRow = getRow head, error = head } :: soFar) [ err ] rest
+
+                dedupeErrs : List DecodingError -> List { startRow : Int, endRow : Int, error : DecodingError }
+                dedupeErrs =
+                    List.sortBy
+                        (\err ->
+                            case err of
+                                FieldDecodingError { problem, row } ->
+                                    case problem of
+                                        ColumnNotFound i ->
+                                            ( 1, "", row )
+
+                                        FieldNotFound name ->
+                                            ( 2, name, row )
+
+                                        ExpectedOneColumn howMany ->
+                                            ( 3, String.fromInt howMany, row )
+
+                                        ExpectedInt notInt ->
+                                            ( 4, notInt, row )
+
+                                        ExpectedFloat notFloat ->
+                                            ( 5, notFloat, row )
+
+                                        Failure custom ->
+                                            ( 6, custom, row )
+
+                                OneOfDecodingError row list ->
+                                    -- This isn't completely foolproof, as if there are more than one
+                                    -- OneOfDecodingErrors per row that have the same number of branches,
+                                    -- this will fail to group them.
+                                    ( 7, String.fromInt (List.length list), row )
+
+                                FieldNotProvided name ->
+                                    ( 8, name, 0 )
+                        )
+                        >> dedupeHelp [] []
+                        >> List.sortBy (\{ startRow } -> startRow)
             in
-            case errs of
+            case dedupeErrs errs of
                 [] ->
                     "Something went wrong, but I got an blank error list so I don't know what it was. Please open an issue!"
 
                 [ only ] ->
-                    errString only
+                    topLevelErrString only
 
-                many ->
+                multiple ->
                     "I saw "
-                        ++ String.fromInt (List.length many)
+                        ++ String.fromInt (List.length multiple)
                         ++ " problems while decoding this CSV:\n\n"
-                        ++ String.join "\n\n" (List.map errString errs)
+                        ++ String.join "\n\n" (List.map topLevelErrString multiple)
 
 
 
@@ -696,9 +782,18 @@ map2 : (a -> b -> c) -> Decoder a -> Decoder b -> Decoder c
 map2 transform (Decoder decodeA) (Decoder decodeB) =
     Decoder
         (\location fieldNames rowNum row ->
-            Result.map2 transform
-                (decodeA location fieldNames rowNum row)
-                (decodeB location fieldNames rowNum row)
+            case ( decodeA location fieldNames rowNum row, decodeB location fieldNames rowNum row ) of
+                ( Ok a, Ok b ) ->
+                    Ok (transform a b)
+
+                ( Err a, Err b ) ->
+                    Err (a ++ b)
+
+                ( Err a, _ ) ->
+                    Err a
+
+                ( _, Err b ) ->
+                    Err b
         )
 
 
@@ -719,10 +814,35 @@ map3 : (a -> b -> c -> d) -> Decoder a -> Decoder b -> Decoder c -> Decoder d
 map3 transform (Decoder decodeA) (Decoder decodeB) (Decoder decodeC) =
     Decoder
         (\location fieldNames rowNum row ->
-            Result.map3 transform
-                (decodeA location fieldNames rowNum row)
-                (decodeB location fieldNames rowNum row)
-                (decodeC location fieldNames rowNum row)
+            case
+                ( decodeA location fieldNames rowNum row
+                , decodeB location fieldNames rowNum row
+                , decodeC location fieldNames rowNum row
+                )
+            of
+                ( Ok a, Ok b, Ok c ) ->
+                    Ok (transform a b c)
+
+                ( Err a, Err b, Err c ) ->
+                    Err (a ++ b ++ c)
+
+                ( Err a, Err b, _ ) ->
+                    Err (a ++ b)
+
+                ( _, Err b, Err c ) ->
+                    Err (b ++ c)
+
+                ( Err a, _, Err c ) ->
+                    Err (a ++ c)
+
+                ( _, _, Err c ) ->
+                    Err c
+
+                ( _, Err b, _ ) ->
+                    Err b
+
+                ( Err a, _, _ ) ->
+                    Err a
         )
 
 
@@ -808,13 +928,16 @@ recover (Decoder first) (Decoder second) =
                 Ok value ->
                     Ok value
 
-                Err err ->
+                Err errs ->
                     case second location fieldNames rowNum row of
                         Ok value ->
                             Ok value
 
-                        Err { problems } ->
-                            Err { err | problems = err.problems ++ problems }
+                        Err [ OneOfDecodingError _ problems ] ->
+                            Err [ OneOfDecodingError rowNum (errs ++ problems) ]
+
+                        Err problems ->
+                            Err [ OneOfDecodingError rowNum (errs ++ problems) ]
 
 
 {-| Decode some value _and then_ make a decoding decision based on the
@@ -872,10 +995,12 @@ fail message =
     Decoder
         (\location fieldNames rowNum _ ->
             Err
-                { row = rowNum
-                , column = locationToColumn fieldNames location
-                , problems = [ Failure message ]
-                }
+                [ FieldDecodingError
+                    { row = rowNum
+                    , column = locationToColumn fieldNames location
+                    , problem = Failure message
+                    }
+                ]
         )
 
 

--- a/src/Csv/Decode.elm
+++ b/src/Csv/Decode.elm
@@ -322,7 +322,7 @@ type Location
     -->         [ FieldDecodingError
     -->           { row = 0
     -->           , column = Column 100
-    -->           , problem =  ColumnNotFound 100
+    -->           , problem = ColumnNotFound 100
     -->           }
     -->         ]
     -->     )

--- a/src/Csv/Decode.elm
+++ b/src/Csv/Decode.elm
@@ -91,7 +91,6 @@ that takes more arguments.
 
 import Csv.Parser as Parser
 import Dict exposing (Dict)
-import Set
 
 
 
@@ -116,6 +115,7 @@ fromString convert =
     Decoder <|
         \location fieldNames rowNum row ->
             let
+                error : Problem -> Result (List DecodingError) a
                 error problem =
                     Err
                         [ FieldDecodingError
@@ -760,7 +760,7 @@ errorToString error =
                             case err of
                                 FieldDecodingError { problem, row } ->
                                     case problem of
-                                        ColumnNotFound i ->
+                                        ColumnNotFound _ ->
                                             ( 1, "", row )
 
                                         FieldNotFound name ->

--- a/tests/Csv/DecodeTest.elm
+++ b/tests/Csv/DecodeTest.elm
@@ -31,10 +31,11 @@ stringTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.ExpectedOneColumn 2 ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.ExpectedOneColumn 2
+                                    }
                                 ]
                             )
                         )
@@ -61,10 +62,11 @@ intTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.ExpectedInt "a" ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.ExpectedInt "a"
+                                    }
                                 ]
                             )
                         )
@@ -75,10 +77,11 @@ intTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.ExpectedOneColumn 2 ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.ExpectedOneColumn 2
+                                    }
                                 ]
                             )
                         )
@@ -110,10 +113,11 @@ floatTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.ExpectedFloat "a" ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.ExpectedFloat "a"
+                                    }
                                 ]
                             )
                         )
@@ -124,10 +128,11 @@ floatTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.ExpectedOneColumn 2 ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.ExpectedOneColumn 2
+                                    }
                                 ]
                             )
                         )
@@ -159,10 +164,11 @@ blankTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.ExpectedInt "banana" ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.ExpectedInt "banana"
+                                    }
                                 ]
                             )
                         )
@@ -194,10 +200,11 @@ columnTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = Column 1
-                                  , problems = [ Decode.ColumnNotFound 1 ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = Column 1
+                                    , problem = Decode.ColumnNotFound 1
+                                    }
                                 ]
                             )
                         )
@@ -213,13 +220,7 @@ fieldTest =
                     |> Decode.decodeCsv NoFieldNames (Decode.field "Name" Decode.string)
                     |> Expect.equal
                         (Err
-                            (DecodingErrors
-                                [ { row = 0
-                                  , column = Field "Name" Nothing
-                                  , problems = [ Decode.FieldNotProvided "Name" ]
-                                  }
-                                ]
-                            )
+                            (DecodingErrors [ Decode.FieldNotProvided "Name" ])
                         )
         , test "fails when the provided headers don't contain the name" <|
             \_ ->
@@ -230,10 +231,7 @@ fieldTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = Field "Name" Nothing
-                                  , problems = [ Decode.FieldNotProvided "Name" ]
-                                  }
+                                [ Decode.FieldNotProvided "Name"
                                 ]
                             )
                         )
@@ -246,11 +244,7 @@ fieldTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 1
-                                  , column = Field "Name" Nothing
-                                  , problems = [ Decode.FieldNotProvided "Name" ]
-                                  }
-                                ]
+                                [ Decode.FieldNotProvided "Name" ]
                             )
                         )
         , test "fails when there is no first row" <|
@@ -269,11 +263,7 @@ fieldTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 1
-                                  , column = Field "Name" Nothing
-                                  , problems = [ Decode.FieldNotProvided "Name" ]
-                                  }
-                                ]
+                                [ Decode.FieldNotProvided "Name" ]
                             )
                         )
         , test "fails when the associated column is not present in the row" <|
@@ -285,10 +275,11 @@ fieldTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 1
-                                  , column = Field "Other" (Just 1)
-                                  , problems = [ Decode.FieldNotFound "Other" ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 1
+                                    , column = Field "Other" (Just 1)
+                                    , problem = Decode.FieldNotFound "Other"
+                                    }
                                 ]
                             )
                         )
@@ -324,10 +315,11 @@ fieldTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 1
-                                  , column = Field "Number" (Just 0)
-                                  , problems = [ Decode.ExpectedInt "not a number" ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 1
+                                    , column = Field "Number" (Just 0)
+                                    , problem = Decode.ExpectedInt "not a number"
+                                    }
                                 ]
                             )
                         )
@@ -396,14 +388,23 @@ oneOfTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems =
-                                        [ Decode.Failure "ONE"
-                                        , Decode.Failure "TWO"
-                                        , Decode.Failure "THREE"
-                                        ]
-                                  }
+                                [ Decode.OneOfDecodingError 0
+                                    [ Decode.FieldDecodingError
+                                        { row = 0
+                                        , column = OnlyColumn
+                                        , problem = Decode.Failure "ONE"
+                                        }
+                                    , Decode.FieldDecodingError
+                                        { row = 0
+                                        , column = OnlyColumn
+                                        , problem = Decode.Failure "TWO"
+                                        }
+                                    , Decode.FieldDecodingError
+                                        { row = 0
+                                        , column = OnlyColumn
+                                        , problem = Decode.Failure "THREE"
+                                        }
+                                    ]
                                 ]
                             )
                         )
@@ -436,10 +437,11 @@ failTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.Failure "a nice description" ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.Failure "a nice description"
+                                    }
                                 ]
                             )
                         )
@@ -450,14 +452,16 @@ failTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.Failure "a nice description" ]
-                                  }
-                                , { row = 1
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.Failure "a nice description" ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.Failure "a nice description"
+                                    }
+                                , Decode.FieldDecodingError
+                                    { row = 1
+                                    , column = OnlyColumn
+                                    , problem = Decode.Failure "a nice description"
+                                    }
                                 ]
                             )
                         )
@@ -493,10 +497,11 @@ andThenTest =
                         |> Expect.equal
                             (Err
                                 (DecodingErrors
-                                    [ { row = 0
-                                      , column = OnlyColumn
-                                      , problems = [ Decode.Failure "Only positive integers are allowed!" ]
-                                      }
+                                    [ Decode.FieldDecodingError
+                                        { row = 0
+                                        , column = OnlyColumn
+                                        , problem = Decode.Failure "Only positive integers are allowed!"
+                                        }
                                     ]
                                 )
                             )
@@ -525,10 +530,11 @@ andThenTest =
                         |> Expect.equal
                             (Err
                                 (DecodingErrors
-                                    [ { row = 0
-                                      , column = Column 3
-                                      , problems = [ Decode.ColumnNotFound 3 ]
-                                      }
+                                    [ Decode.FieldDecodingError
+                                        { row = 0
+                                        , column = Column 3
+                                        , problem = Decode.ColumnNotFound 3
+                                        }
                                     ]
                                 )
                             )
@@ -557,10 +563,11 @@ fromResultTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.Failure "\"banana\" is not a valid hexadecimal string because n is not a valid hexadecimal character." ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.Failure "\"banana\" is not a valid hexadecimal string because n is not a valid hexadecimal character."
+                                    }
                                 ]
                             )
                         )
@@ -588,11 +595,54 @@ fromMaybeTest =
                     |> Expect.equal
                         (Err
                             (DecodingErrors
-                                [ { row = 0
-                                  , column = OnlyColumn
-                                  , problems = [ Decode.Failure "Expected an int" ]
-                                  }
+                                [ Decode.FieldDecodingError
+                                    { row = 0
+                                    , column = OnlyColumn
+                                    , problem = Decode.Failure "Expected an int"
+                                    }
                                 ]
                             )
                         )
+        ]
+
+
+testErrorToString : Test
+testErrorToString =
+    describe "errorToString"
+        [ test "groups simple errors" <|
+            \() ->
+                "a\na\na"
+                    |> Decode.decodeCsv NoFieldNames Decode.int
+                    |> Result.mapError Decode.errorToString
+                    |> Expect.equal (Err "There was a problem on rows 0–2, column 0 (the only column present): I could not parse an int from `a`.")
+        , test "groups simple errors in more complex settings - errors are sorted by row occurence" <|
+            \() ->
+                "a\na\nb\na\na"
+                    |> Decode.decodeCsv NoFieldNames Decode.int
+                    |> Result.mapError Decode.errorToString
+                    |> Expect.equal (Err "I saw 3 problems while decoding this CSV:\n\nThere was a problem on rows 0 and 1, column 0 (the only column present): I could not parse an int from `a`.\n\nThere was a problem on row 2, column 0 (the only column present): I could not parse an int from `b`.\n\nThere was a problem on rows 3 and 4, column 0 (the only column present): I could not parse an int from `a`.")
+        , test "works with map2" <|
+            \() ->
+                "foo,bar\na,2\na,b\na,c"
+                    |> Decode.decodeCsv FieldNamesFromFirstRow (Decode.map2 Tuple.pair (Decode.field "foo" Decode.int) (Decode.field "bar" Decode.int))
+                    |> Result.mapError Decode.errorToString
+                    |> Expect.equal (Err "I saw 3 problems while decoding this CSV:\n\nThere was a problem on rows 1–3, in the `foo` field (column 0): I could not parse an int from `a`.\n\nThere was a problem on row 2, in the `bar` field (column 1): I could not parse an int from `b`.\n\nThere was a problem on row 3, in the `bar` field (column 1): I could not parse an int from `c`.")
+        , test "works with oneOf" <|
+            \() ->
+                "a\n1\n1.2"
+                    |> Decode.decodeCsv NoFieldNames (Decode.oneOf (Decode.map toFloat Decode.int) [ Decode.float ])
+                    |> Result.mapError Decode.errorToString
+                    |> Expect.equal (Err "There was a problem on row 0 - all of the following decoders failed, but at least one must succeed:\n  (1) column 0 (the only column present): I could not parse an int from `a`.\n  (2) column 0 (the only column present): I could not parse a float from `a`.")
+        , test "works with nested oneOf" <|
+            \() ->
+                "a\n1\n1.2"
+                    |> Decode.decodeCsv NoFieldNames (Decode.oneOf Decode.float [ Decode.oneOf (Decode.map toFloat Decode.int) [ Decode.float ] ])
+                    |> Result.mapError Decode.errorToString
+                    |> Expect.equal (Err "There was a problem on row 0 - all of the following decoders failed, but at least one must succeed:\n  (1) column 0 (the only column present): I could not parse a float from `a`.\n  (2) column 0 (the only column present): I could not parse an int from `a`.\n  (3) column 0 (the only column present): I could not parse a float from `a`.")
+        , test "works with complex decoder" <|
+            \() ->
+                "foo,bar\na,2\na,b\na,c"
+                    |> Decode.decodeCsv FieldNamesFromFirstRow (Decode.map2 Tuple.pair (Decode.oneOf (Decode.field "foo" Decode.int) [ Decode.field "bar" (Decode.map round Decode.float) ]) (Decode.field "bar" Decode.int))
+                    |> Result.mapError Decode.errorToString
+                    |> Expect.equal (Err "I saw 4 problems while decoding this CSV:\n\nThere was a problem on row 2, in the `bar` field (column 1): I could not parse an int from `b`.\n\nThere was a problem on row 2 - all of the following decoders failed, but at least one must succeed:\n  (1) in the `foo` field (column 0): I could not parse an int from `a`.\n  (2) in the `bar` field (column 1): I could not parse a float from `b`.\n\nThere was a problem on row 3, in the `bar` field (column 1): I could not parse an int from `c`.\n\nThere was a problem on row 3 - all of the following decoders failed, but at least one must succeed:\n  (1) in the `foo` field (column 0): I could not parse an int from `a`.\n  (2) in the `bar` field (column 1): I could not parse a float from `c`.")
         ]


### PR DESCRIPTION
Fixes #32. Fixes #22. Closes #31.

This has a fairly sever refactor of the error handling, but the outcome is that `map2` and friends don't loose errors, and `oneOf` has easier to understand error messages (which are also more explicitely represented in the types).